### PR TITLE
add-status-to-response-json

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,11 +21,11 @@ type DogList struct {
 	Status  string `json:"status"`
 }
 
-func (dogList DogList) status() {
-	fmt.Println(dogList.Message)
+func (dogList *DogList) status() {
 	if len(dogList.Message) != 0 {
 		dogList.Status = "success"
 	} else {
+		dogList.Message = []Dog{}
 		dogList.Status = "failed"
 	}
 }
@@ -84,7 +84,6 @@ func getDogHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		response.status()
-		fmt.Println(len(response.Message))
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(response)


### PR DESCRIPTION
keywordにマッチしない単語を指定するとresponse jsonのstatusをfailedにして返すようにしました。